### PR TITLE
Add Jaeger for trace visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ curl "127.0.0.1:8080/api/v1/users?limit=10"
 | Grafana         | http://127.0.0.1:3000     | admin / admin |
 | Prometheus      | http://127.0.0.1:9090     | –             |
 | Tempo (API)     | http://127.0.0.1:3200     | –             |
+| Jaeger UI       | http://127.0.0.1:16686    | –             |
 | DynamoDB Admin  | http://127.0.0.1:8001     | –             |
 | LocalStack      | http://127.0.0.1:4566     | –             |
 
-A aplicação exporta traces e métricas via OTLP (`127.0.0.1:4317`) para o OTEL Collector, que distribui para Tempo (traces) e Prometheus (métricas). O Grafana já vem com os datasources provisionados e um dashboard de HTTP. O **DynamoDB Admin** permite navegar pelas tabelas do DynamoDB no LocalStack.
+A aplicação exporta traces e métricas via OTLP (`127.0.0.1:4317`) para o OTEL Collector, que distribui para Tempo e Jaeger (traces) e Prometheus (métricas). O Grafana já vem com os datasources provisionados e um dashboard de HTTP. O **DynamoDB Admin** permite navegar pelas tabelas do DynamoDB no LocalStack.
 
 ## Comandos úteis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - "4318:4318"   # OTLP HTTP
     depends_on:
       - tempo
+      - jaeger
 
   prometheus:
     image: prom/prometheus:v2.55.0
@@ -68,6 +69,14 @@ services:
       - tempodata:/var/tempo
     ports:
       - "3200:3200"   # Tempo query API
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    container_name: bp_jaeger
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "16686:16686"   # Jaeger UI
 
   grafana:
     image: grafana/grafana:11.3.0

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -18,6 +18,12 @@ exporters:
     tls:
       insecure: true
 
+  # Traces -> Jaeger (OTLP gRPC).
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
   # Metrics -> Prometheus scrape endpoint exposed by the collector.
   prometheus:
     endpoint: 0.0.0.0:8889
@@ -27,7 +33,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tempo]
+      exporters: [otlp/tempo, otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
## Summary

Adds **Jaeger** (all-in-one) as a dedicated trace UI, running via Docker alongside the existing Tempo + Grafana stack.

## Changes

- New `jaeger` service (`jaegertracing/all-in-one`) with OTLP enabled; UI on `http://127.0.0.1:16686`.
- OTEL Collector now fans out traces to **both Tempo and Jaeger** (`otlp/tempo` + `otlp/jaeger` exporters in the traces pipeline).
- README updated (services table + Jaeger UI).

## Validation

- `docker compose up -d jaeger` + collector recreated; traffic generated.
- Confirmed in Jaeger API: service `boilerplate-api` registered and traces (`http.server`) visible.

Infra-only change; no Go code touched.