### PR TITLE
Enforce >=99% coverage on new code; upgrade to Go 1.26

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Local pre-commit gate: code must build, vet clean, and unit tests must pass
+# before a commit is created. The authoritative >=99% new-code coverage gate
+# runs in CI (see .github/workflows/ci.yml, job "New-code coverage").
+#
+# Install once after cloning:  make hooks
+# Bypass in an emergency:       git commit --no-verify   (discouraged)
+set -e
+
+echo "[pre-commit] go vet ./..."
+go vet ./...
+
+echo "[pre-commit] go build ./..."
+go build ./...
+
+echo "[pre-commit] go test ./..."
+go test ./...
+
+echo "[pre-commit] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
 
       - name: Download dependencies
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
       - name: Run integration tests
         run: go test -tags integration ./...
@@ -64,9 +64,43 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
+
+  coverage:
+    name: New-code coverage (>=99%)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Unit tests with coverage
+        run: go test -covermode=atomic -coverprofile=coverage.out ./...
+      - name: Enforce >=99% coverage on new code
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git diff -U0 --no-color "origin/${BASE_REF}...HEAD" > coverage.patch
+          go run github.com/seriousben/go-patch-cover/cmd/go-patch-cover@v0.2.0 \
+            -o json coverage.out coverage.patch > coverage.patch.json
+          cat coverage.patch.json
+          n=$(jq -r '.patch_num_stmt' coverage.patch.json)
+          cov=$(jq -r '.patch_coverage' coverage.patch.json)
+          if [ "$n" -eq 0 ]; then
+            echo "No new Go statements in this PR; coverage gate skipped."
+            exit 0
+          fi
+          awk -v c="$cov" -v t="99" 'BEGIN{
+            if (c+0 < t+0) { printf("FAIL: new-code coverage %.2f%% < %d%%\n", c, t); exit 1 }
+            printf("OK: new-code coverage %.2f%% >= %d%%\n", c, t)
+          }'

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,22 @@ test: ## Run unit tests with race detector and coverage
 test-integration: ## Run integration tests (requires infra up: make infra-up)
 	go test -tags integration ./...
 
+.PHONY: cover
+cover: ## Run unit tests and report total coverage
+	go test -covermode=atomic -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out | tail -1
+
+.PHONY: cover-diff
+cover-diff: ## New-code coverage vs origin/main (CI enforces >=99%)
+	go test -covermode=atomic -coverprofile=coverage.out ./...
+	git diff -U0 --no-color origin/main...HEAD > coverage.patch
+	go run github.com/seriousben/go-patch-cover/cmd/go-patch-cover@v0.2.0 coverage.out coverage.patch
+
+.PHONY: hooks
+hooks: ## Install local git hooks (run once after clone)
+	git config core.hooksPath .githooks
+	@echo "git hooks installed (core.hooksPath=.githooks)"
+
 .PHONY: vet
 vet: ## Run go vet
 	go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bandrosh/boilerplate-api
 
-go 1.24
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0


### PR DESCRIPTION
## What
1. **Coverage gate (two layers):**
   - **Local pre-commit hook** (`.githooks/pre-commit`) — `go vet`, `go build`, `go test ./...`
     before every commit. Install once with `make hooks`.
   - **CI diff-coverage gate** (`coverage` job, pull requests only) — fails when new-code
     coverage is `< 99%`. Go-native (no Python), via `go-patch-cover`; skips when the PR adds
     no new Go statements.
   - Makefile targets: `hooks`, `cover`, `cover-diff`.
2. **Go 1.26 upgrade** — `go.mod` and all CI jobs moved from 1.24 to 1.26 (aligns with
   auth-api and account-api). The lint job now uses `install-mode: goinstall` so
   golangci-lint compiles with the CI Go toolchain (avoids the prebuilt-binary mismatch).

## Why
- Coverage was printed but never enforced; the diff gate makes the ≥99% floor real without
  penalizing legacy code.
- Keeping the three services on the same Go version avoids toolchain drift.

## Notes
- The coverage gate runs on pull requests only (a push to `main` has no diff base).
- Verified locally on 1.26: `go vet` and `go build` clean.