### PR TITLE
chore(ci): new-code coverage gate to 95% and exclude composition root

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Local pre-commit gate: code must build, vet clean, and unit tests must pass
-# before a commit is created. The authoritative >=99% new-code coverage gate
+# before a commit is created. The authoritative >=95% new-code coverage gate
 # runs in CI (see .github/workflows/ci.yml, job "New-code coverage").
 #
 # Install once after cloning:  make hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           install-mode: goinstall
 
   coverage:
-    name: New-code coverage (>=99%)
+    name: New-code coverage (>=95%)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -86,11 +86,14 @@ jobs:
           cache: true
       - name: Unit tests with coverage
         run: go test -covermode=atomic -coverprofile=coverage.out ./...
-      - name: Enforce >=99% coverage on new code
+      - name: Enforce >=95% coverage on new code
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git diff -U0 --no-color "origin/${BASE_REF}...HEAD" > coverage.patch
+          # Composition root (cmd/api/main.go) wires live AWS clients and is
+          # not unit-testable; exclude it from the new-code coverage gate.
+          git diff -U0 --no-color "origin/${BASE_REF}...HEAD" \
+            -- . ':(exclude)cmd/api/main.go' > coverage.patch
           go run github.com/seriousben/go-patch-cover/cmd/go-patch-cover@v0.2.0 \
             -o json coverage.out coverage.patch > coverage.patch.json
           cat coverage.patch.json
@@ -100,7 +103,7 @@ jobs:
             echo "No new Go statements in this PR; coverage gate skipped."
             exit 0
           fi
-          awk -v c="$cov" -v t="99" 'BEGIN{
+          awk -v c="$cov" -v t="95" 'BEGIN{
             if (c+0 < t+0) { printf("FAIL: new-code coverage %.2f%% < %d%%\n", c, t); exit 1 }
             printf("OK: new-code coverage %.2f%% >= %d%%\n", c, t)
           }'

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ cover: ## Run unit tests and report total coverage
 	go tool cover -func=coverage.out | tail -1
 
 .PHONY: cover-diff
-cover-diff: ## New-code coverage vs origin/main (CI enforces >=99%)
+cover-diff: ## New-code coverage vs origin/main (CI enforces >=95%)
 	go test -covermode=atomic -coverprofile=coverage.out ./...
-	git diff -U0 --no-color origin/main...HEAD > coverage.patch
+	git diff -U0 --no-color origin/main...HEAD -- . ':(exclude)cmd/api/main.go' > coverage.patch
 	go run github.com/seriousben/go-patch-cover/cmd/go-patch-cover@v0.2.0 coverage.out coverage.patch
 
 .PHONY: hooks


### PR DESCRIPTION
## What
Lower the CI **new-code coverage gate from 99% to 95%** and **exclude the composition root** `cmd/api/main.go` from the measured diff. Applies the same change to the `coverage` CI job, the `cover-diff` Makefile target and the pre-commit note.

## Why
`cmd/api/main.go` wires live AWS/KMS/DynamoDB clients and is not unit-testable, but the 99% gate forced coverage onto it, blocking otherwise-well-tested PRs. 95% on new code (minus the composition root) keeps a high bar on real logic while matching common diff-coverage practice. Rolled across all services for consistency (auth-api already carries this in #5).

## Notes
- No Go statements change, so the coverage job self-skips on this PR.