### PR TITLE
chore(infra): replace LocalStack with Floci as the local AWS emulator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ SHUTDOWN_TIMEOUT=15s
 LOG_LEVEL=debug          # debug | info | warn | error
 LOG_FORMAT=text          # text (dev) | json (prod)
 
-# ─── AWS / DynamoDB (points to the dockerized LocalStack) ────
+# ─── AWS / DynamoDB (points to the dockerized Floci) ─────────
 AWS_REGION=us-east-1
 # 127.0.0.1 (not localhost) avoids IPv6 (::1) resolution issues with Docker
 # published ports on Windows/macOS.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,16 @@ jobs:
         run: go test -race -cover ./...
 
   integration:
-    name: Integration (DynamoDB/LocalStack)
+    name: Integration (DynamoDB/Floci)
     runs-on: ubuntu-latest
     services:
-      localstack:
-        image: localstack/localstack:3.8
+      floci:
+        image: floci/floci:1.5.34-compat
         ports:
           - 4566:4566
         env:
-          SERVICES: dynamodb
+          FLOCI_DEFAULT_REGION: us-east-1
+          FLOCI_STORAGE_MODE: memory
         options: >-
           --health-cmd "awslocal dynamodb list-tables"
           --health-interval 5s

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ fmt: ## Format the codebase
 
 # ─── Infrastructure (Docker = infra only) ────────────────────
 .PHONY: infra-up
-infra-up: ## Start LocalStack (DynamoDB) + observability stack
+infra-up: ## Start Floci (DynamoDB) + observability stack
 	docker compose up -d
 
 .PHONY: infra-down
@@ -79,15 +79,15 @@ infra-clean: ## Stop infra and delete volumes
 logs: ## Tail infrastructure logs
 	docker compose logs -f
 
-# ─── DynamoDB helpers (LocalStack) ───────────────────────────
+# ─── DynamoDB helpers (Floci) ────────────────────────────────
 .PHONY: db-tables
-db-tables: ## List DynamoDB tables in LocalStack
-	docker compose exec localstack awslocal dynamodb list-tables
+db-tables: ## List DynamoDB tables in Floci
+	docker compose exec floci awslocal dynamodb list-tables
 
 .PHONY: db-scan
 db-scan: ## Scan the table (debug only)
-	docker compose exec localstack awslocal dynamodb scan --table-name $(DYNAMODB_TABLE)
+	docker compose exec floci awslocal dynamodb scan --table-name $(DYNAMODB_TABLE)
 
 .PHONY: db-recreate
-db-recreate: ## Re-run the table init script inside LocalStack
-	docker compose exec localstack bash /etc/localstack/init/ready.d/01-create-tables.sh
+db-recreate: ## Re-run the table init script inside Floci
+	docker compose exec floci bash /etc/localstack/init/ready.d/01-create-tables.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 REST API boilerplate in **Go**, built with a **Hexagonal (Ports & Adapters) + DDD-lite** architecture, ready for robust production projects.
 
-The application **runs from the IDE / locally** (`go run ./cmd/api`); **Docker contains infrastructure only** (LocalStack/DynamoDB + an observability stack with Grafana).
+The application **runs from the IDE / locally** (`go run ./cmd/api`); **Docker contains infrastructure only** (Floci/DynamoDB + an observability stack with Grafana).
 
 ## Stack
 
@@ -10,7 +10,7 @@ The application **runs from the IDE / locally** (`go run ./cmd/api`); **Docker c
 |------------------|--------------------------------------------------------|
 | HTTP router      | [chi](https://github.com/go-chi/chi)                   |
 | Persistence      | **DynamoDB** ([AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2)) — single-table design |
-| Local AWS        | [LocalStack](https://localstack.cloud)                 |
+| Local AWS        | [Floci](https://floci.io) (drop-in LocalStack replacement) |
 | Config           | env + `.env` ([caarlos0/env](https://github.com/caarlos0/env), godotenv) |
 | Logging          | `log/slog` (structured)                                |
 | Observability    | OpenTelemetry → OTEL Collector → Prometheus / Tempo / Grafana |
@@ -26,7 +26,7 @@ internal/
     http                   # inbound adapter (chi): router, handlers, dto, middleware
     dynamodb               # outbound adapter: AWS SDK v2 client, single-table repository
   platform/                # cross-cutting: config, logger, observability, server
-docker/                    # infra configs (localstack init, otel, prometheus, tempo, grafana)
+docker/                    # infra configs (floci init, otel, prometheus, tempo, grafana)
 ```
 
 The dependency rule points **inward**: `adapter → application → domain`. The domain knows nothing about HTTP or DynamoDB; adapters implement the *ports* defined in the domain. Swapping persistence (e.g. DynamoDB → Postgres) only affects the outbound adapter.
@@ -51,9 +51,9 @@ A single table (`boilerplate`) with generic `PK`/`SK` keys and a global index `G
 
 ### 2. Start the infrastructure
 ```bash
-make infra-up        # localstack(dynamodb) + otel-collector + prometheus + tempo + grafana
+make infra-up        # floci(dynamodb) + otel-collector + prometheus + tempo + grafana
 ```
-LocalStack creates the table automatically via the init script (`docker/localstack/init`).
+Floci creates the table automatically via the init script (`docker/floci/init`).
 Check it with `make db-tables`.
 
 ### 3. Configure the environment
@@ -102,15 +102,15 @@ curl "127.0.0.1:8080/api/v1/users?limit=10"
 | Tempo (API)     | http://127.0.0.1:3200     | –             |
 | Jaeger UI       | http://127.0.0.1:16686    | –             |
 | DynamoDB Admin  | http://127.0.0.1:8001     | –             |
-| LocalStack      | http://127.0.0.1:4566     | –             |
+| Floci (AWS)     | http://127.0.0.1:4566     | –             |
 
-The application exports traces and metrics via OTLP (`127.0.0.1:4317`) to the OTEL Collector, which fans out to Tempo and Jaeger (traces) and Prometheus (metrics). Grafana ships with provisioned datasources and an HTTP dashboard. **DynamoDB Admin** lets you browse the DynamoDB tables in LocalStack.
+The application exports traces and metrics via OTLP (`127.0.0.1:4317`) to the OTEL Collector, which fans out to Tempo and Jaeger (traces) and Prometheus (metrics). Grafana ships with provisioned datasources and an HTTP dashboard. **DynamoDB Admin** lets you browse the DynamoDB tables in Floci.
 
 ## Useful commands
 
 ```bash
 make help            # list all targets
-make db-tables       # list DynamoDB tables (LocalStack)
+make db-tables       # list DynamoDB tables (Floci)
 make db-scan         # scan the table (debug)
 make test            # unit tests (-race and coverage)
 make test-integration # integration tests (requires infra: make infra-up)
@@ -121,7 +121,7 @@ make infra-down      # tear down the infra
 ## Tests
 
 - **Unit:** domain (`internal/domain/user`) and use cases (`internal/application/user`, with a fake repository). Always run: `make test`.
-- **Integration:** DynamoDB repository against LocalStack, behind the `integration` build tag. Start the infra (`make infra-up`) and run `make test-integration`. CI has a dedicated job with LocalStack.
+- **Integration:** DynamoDB repository against Floci, behind the `integration` build tag. Start the infra (`make infra-up`) and run `make test-integration`. CI has a dedicated job with Floci.
 
 ## Adding a new feature
 
@@ -129,4 +129,4 @@ make infra-down      # tear down the infra
 2. Write the use cases in `internal/application/<feature>`.
 3. Implement the repository in `internal/adapter/dynamodb` (define the key pattern in the single table).
 4. Expose it via handlers in `internal/adapter/http` and mount it in `router.go`.
-5. If you need new tables/indexes, adjust the init in `docker/localstack/init`.
+5. If you need new tables/indexes, adjust the init in `docker/floci/init`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,25 @@
 name: boilerplate-api
 
 services:
-  localstack:
-    image: localstack/localstack:3.8
-    container_name: bp_localstack
+  # Floci is a drop-in LocalStack replacement (same port, same wire protocol).
+  # The `-compat` tag bundles the AWS CLI / awslocal used by the init script.
+  floci:
+    image: floci/floci:1.5.34-compat
+    container_name: bp_floci
     environment:
-      SERVICES: dynamodb
-      DEBUG: "0"
+      FLOCI_HOSTNAME: floci          # hostname used in URLs returned to other containers
+      FLOCI_DEFAULT_REGION: us-east-1
+      FLOCI_STORAGE_MODE: hybrid     # in-memory with async flush to disk
       AWS_DEFAULT_REGION: us-east-1
       DYNAMODB_TABLE: boilerplate
     ports:
-      - "4566:4566"   # LocalStack edge / DynamoDB endpoint
+      - "4566:4566"   # Floci edge / DynamoDB endpoint
     volumes:
-      # Init scripts under ready.d run automatically once LocalStack is ready.
-      - ./docker/localstack/init:/etc/localstack/init/ready.d:ro
-      - localstackdata:/var/lib/localstack
+      # Init scripts under ready.d run automatically once Floci is ready.
+      - ./docker/floci/init:/etc/localstack/init/ready.d:ro
+      # /app/data is Floci's default persistent path and is owned by the
+      # non-root container user, so the named volume inherits its permissions.
+      - flocidata:/app/data
     healthcheck:
       test: ["CMD-SHELL", "awslocal dynamodb list-tables || exit 1"]
       interval: 5s
@@ -28,14 +33,14 @@ services:
     image: aaronshaf/dynamodb-admin:4.6.1
     container_name: bp_dynamodb_admin
     environment:
-      DYNAMO_ENDPOINT: http://localstack:4566
+      DYNAMO_ENDPOINT: http://floci:4566
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
     ports:
       - "8001:8001"   # DynamoDB Admin UI
     depends_on:
-      - localstack
+      - floci
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.111.0
@@ -96,6 +101,6 @@ services:
       - tempo
 
 volumes:
-  localstackdata:
+  flocidata:
   tempodata:
   grafanadata:

--- a/docker/floci/init/01-create-tables.sh
+++ b/docker/floci/init/01-create-tables.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs automatically inside the LocalStack container once it is ready.
+# Runs automatically inside the Floci container once it is ready.
 # Creates the single-table-design table with a generic GSI1.
 set -euo pipefail
 


### PR DESCRIPTION
## Description

LocalStack's community edition now requires an auth token, which breaks unattended local setup and CI. This PR swaps it for [Floci](https://github.com/floci-io/floci), a drop-in replacement: same `:4566` endpoint, same wire protocol, same `/etc/localstack/init/ready.d` init layout, MIT licensed and token free.

### Changes

- **docker-compose**: `localstack/localstack:3.8` -> `floci/floci:1.5.34-compat` (the `-compat` tag ships `awslocal`/`aws`, used by the init script and the healthcheck). State persists on the `flocidata` volume mounted at `/app/data` — Floci's default persistent path, owned by the non-root container user, so a named volume inherits writable permissions. `FLOCI_HOSTNAME=floci` keeps returned URLs resolvable from sibling containers (dynamodb-admin).
- **docker/localstack -> docker/floci**: directory rename only; the table init script runs unchanged.
- **CI**: the integration job now uses the Floci service container (`FLOCI_STORAGE_MODE=memory`).
- **Makefile / README / .env.example**: DynamoDB helper targets and docs point at Floci.

No application code changed.

## Test scenarios

Executed locally against `floci/floci:1.5.34-compat`:

| Scenario | Result |
|---|---|
| `docker compose up -d floci` -> container healthcheck (`awslocal dynamodb list-tables`) | `healthy` |
| Init script runs unchanged from `ready.d` | table `boilerplate` created, `ACTIVE`, `GSI1` present, `PAY_PER_REQUEST` |
| `go test -tags integration ./...` (repository suite: create/get/list/update/delete, TransactWriteItems email lock, GSI1 cursor pagination) | pass |
| dynamodb-admin at `http://127.0.0.1:8001` via `http://floci:4566` | HTTP 200, table listed |
| API smoke: `go run ./cmd/api` -> `GET /readyz` | 200 |
| API smoke: `POST /api/v1/users` | 201, user persisted |
| API smoke: `GET /api/v1/users?limit=5` | 200, item returned with cursor |
| `go vet ./...` / `go build ./...` / `go test -cover ./...` | pass (`-race` skipped locally: no gcc on this box; CI runs it) |